### PR TITLE
Replace min_timestamp filter with escalated_min_date

### DIFF
--- a/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.py
+++ b/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.py
@@ -27,8 +27,12 @@ FetchIncidentsStorage = TypedDict("FetchIncidentsStorage", {
 """ CLIENT """
 
 ALLOWED_SORT_FIELDS = ["timestamp", "last_modified"]
-ALLOWED_ALERT_FILTERS = ["last_modified_min_date",
-                         "min_timestamp", "max_timestamp"]
+ALLOWED_ALERT_FILTERS = [
+    "last_modified_min_date",
+    "escalated_min_date",
+    "min_timestamp",
+    "max_timestamp"
+]
 
 
 class ZFClient(BaseClient):
@@ -154,6 +158,11 @@ class ZFClient(BaseClient):
                         text=raw_response.text
                     )
                 )
+            if raw_response.status_code == 429:
+                raise ZeroFoxAuthException(
+                    cause="The application is sending too many requests to ZeroFox API,\
+                          please contact support."
+                    )
             response = raw_response.json()
             if non_field_errors := response.get("non_field_errors", []):
                 raise ZeroFoxAuthException(cause=non_field_errors[0])
@@ -1301,15 +1310,26 @@ def _build_incidents_given_last_fetch(
     is_valid_alert: Callable[[dict[str, Any]], bool],
 ) -> tuple[list[dict[str, Any]], datetime, list[str]]:
 
-    alerts = [
-        alert for alert in client.get_alerts(
-            filter_by={
-                "min_timestamp": created_since.strftime(DATE_FORMAT)},
-            sort_by="timestamp",
-            sort_direction="asc"
-        )
-        if is_valid_alert(alert)
-    ]
+    if client.only_escalated:
+        alerts = [
+            alert for alert in client.get_alerts(
+                filter_by={
+                    "escalated_min_date": created_since.strftime(DATE_FORMAT)},
+                sort_by="timestamp",
+                sort_direction="asc"
+            )
+            if is_valid_alert(alert)
+        ]
+    else:
+        alerts = [
+            alert for alert in client.get_alerts(
+                filter_by={
+                    "min_timestamp": created_since.strftime(DATE_FORMAT)},
+                sort_by="timestamp",
+                sort_direction="asc"
+            )
+            if is_valid_alert(alert)
+        ]
     if not alerts:
         return [], created_since, []
 


### PR DESCRIPTION
Applications configured to only include escalated alerts had an issue where the application fetched all alerts created within the defined timeframe, that were escalated. 

This led to alerts created recently but not escalated within the timeframe to be missed. This fix allows for alerts created when only asking for escalated alerts are those that were escalated recently, rather than those created recently.


## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Must have
- [ ] Tests
- [ ] Documentation 
